### PR TITLE
fix: tsdb metric query

### DIFF
--- a/packages/sandbox-core/src/core/dataSource/tsdb.ts
+++ b/packages/sandbox-core/src/core/dataSource/tsdb.ts
@@ -83,7 +83,7 @@ export class TSDB {
     this.logger.info('[TSDB]', finalUrl);
     const options = {
       dataType: 'json',
-      timeout: 5000,
+      timeout: 10000,
       ...opts,
       headers: {
         ...this.config.extHeaders || null,

--- a/packages/sandbox-core/src/core/manager/metricsManager.ts
+++ b/packages/sandbox-core/src/core/manager/metricsManager.ts
@@ -1,4 +1,5 @@
 import { provide, inject } from 'midway-mirror';
+import * as _ from 'lodash';
 import {AppSelector, IndicatorResult, MetricNameJSON, TimeWindowOptions} from '../../interface/services/common';
 import {TSDB} from '../dataSource/tsdb';
 import {ISadMetricsAdapter} from '../../interface/adapter/ISadMetricsAdapter';
@@ -13,6 +14,9 @@ export class MetricsManager {
   protected sadMetricsAdapter: ISadMetricsAdapter;
 
   static pickLatestDp (dps) {
+    if (_.isEmpty(dps)) {
+      return null;
+    }
     let times = [];
     for (const key of Object.keys(dps)) {
       times.push(parseInt(key, 10));

--- a/packages/sandbox-core/src/core/service/metricsService.ts
+++ b/packages/sandbox-core/src/core/service/metricsService.ts
@@ -50,6 +50,7 @@ export class MetricsService implements IMetricsService {
 
     const resp = await this.tsdb.query({
       start: '6m-ago',
+      end: '1m-ago',
       queries,
     });
 

--- a/packages/sandbox-core/test/core/manager/metricsManager.test.ts
+++ b/packages/sandbox-core/test/core/manager/metricsManager.test.ts
@@ -7,12 +7,15 @@ import mm = require('mm');
 describe('test/core/manager/metricsManager.test.ts', () => {
 
   it('should static pickLatestDp() be ok', () => {
-    const latest = MetricsManager.pickLatestDp({
+    let latest = MetricsManager.pickLatestDp({
       123: '123',
       456: '456',
       1000: 'latest',
     });
     assert('latest' === latest);
+
+    latest = MetricsManager.pickLatestDp({});
+    assert(null === latest);
   });
 
   it('should getMetricsNames() be ok', async () => {

--- a/packages/sandbox-mvp/package.json
+++ b/packages/sandbox-mvp/package.json
@@ -16,7 +16,7 @@
     "ts-node": "^7.0.0",
     "tslib": "^1.8.1",
     "tslint": "^5.9.1",
-    "typescript": "^2.8.0",
+    "typescript": "^3.2.2",
     "webstorm-disable-index": "^1.2.0"
   },
   "engines": {


### PR DESCRIPTION
增加查询 latestMetric 时的 end 参数；
查询结果为空时的返回值为 null；
tsdb 查询超时时间从 5s 延长为 10s；