### PR TITLE
fix: allow admin access remote debug

### DIFF
--- a/packages/sandbox-core/src/app/controller/remoteDebugCtrl.ts
+++ b/packages/sandbox-core/src/app/controller/remoteDebugCtrl.ts
@@ -1,5 +1,6 @@
 import { get, controller, provide, inject, priority } from 'midway-mirror';
 import { RemoteDebugService } from '../../core/service/remoteDebugService';
+import { IPrivilegeAdapter } from '../../interface/adapter/IPrivilegeAdapter';
 
 @priority(0)
 @provide()
@@ -9,12 +10,19 @@ export class RemoteDebugCtrl {
   @inject('remoteDebugService')
   remoteDebugService: RemoteDebugService;
 
+  @inject('privilegeAdapter')
+  protected privilegeAdapter: IPrivilegeAdapter;
+
   @get('/getDebuggableHost')
   async getDebuggableHost(ctx) {
 
     const query = ctx.query;
     const { scope, scopeName, env, ip, hostname } = query;
     const uid: string = ctx.uid;
+    const hasPermission = await this.privilegeAdapter.isAppOps(scope, scopeName, uid);
+    if (!hasPermission) {
+      throw new Error('You have no permission to reach this');
+    }
     const data =  await this.remoteDebugService.getDebuggableHost({
       scope, scopeName, env, ip, hostname, uid,
     });

--- a/packages/sandbox-core/src/app/middleware/user.ts
+++ b/packages/sandbox-core/src/app/middleware/user.ts
@@ -1,0 +1,12 @@
+import * as assert from 'assert';
+
+export default function admin(options, app) {
+  return async (ctx, next) => {
+    /*
+      TODO: implement of user middleware here
+    */
+
+    assert(ctx.uid, 'must implement user middleware and set ctx.uid');
+    await next();
+  };
+}

--- a/packages/sandbox-core/src/core/service/remoteDebugService.ts
+++ b/packages/sandbox-core/src/core/service/remoteDebugService.ts
@@ -3,7 +3,6 @@ import { DebuggableHost, HostSelector, AppSelector, UserSelector } from '../../i
 import {PandoraAdapter} from '../adapter/pandoraAdapter';
 import {Cipher} from '../debugServer/cipher';
 import {IRemoteDebugService} from '../../interface/services/IRemoteDebugService';
-import {IPrivilegeAdapter} from '../../interface/adapter/IPrivilegeAdapter';
 
 @provide('remoteDebugService')
 export class RemoteDebugService implements IRemoteDebugService {
@@ -11,15 +10,8 @@ export class RemoteDebugService implements IRemoteDebugService {
   @inject('pandoraAdapter')
   protected pandoraAdapter: PandoraAdapter;
 
-  @inject('privilegeAdapter')
-  protected privilegeAdapter: IPrivilegeAdapter;
-
   async getDebuggableHost(options: HostSelector & AppSelector & UserSelector): Promise<DebuggableHost> {
-    const {scope, scopeName, uid} = options;
-    const hasPermission = await this.privilegeAdapter.isAppOps(scope, scopeName, uid);
-    if (!hasPermission) {
-      throw new Error('You have no permission to reach this');
-    }
+    const {uid} = options;
     const debuggableProcesses = await this.pandoraAdapter.getDebuggableProcesses(options);
     for (const process of debuggableProcesses) {
       process.token = Cipher.encrypt(JSON.stringify({

--- a/packages/sandbox-core/test/app/controller/remoteDebugCtrl.test.ts
+++ b/packages/sandbox-core/test/app/controller/remoteDebugCtrl.test.ts
@@ -1,0 +1,30 @@
+import * as assert from 'assert';
+import { getInstance } from '../../helper';
+
+describe('remoteDebugCtrltest', async () => {
+
+  it('getDebuggableHost without permission', async () => {
+    const remoteDebugCtrl = await getInstance('remoteDebugCtrl');
+    let throwError = false;
+    try {
+      await remoteDebugCtrl.getDebuggableHost({
+        uid: '1001',
+        query: {
+          scope: 'test',
+          scopeName: 'noPermission',
+          uid: '1001',
+          ip: '127.0.0.1',
+        }
+      });
+    } catch (err) {
+      if (err.message.match(/no permission/)) {
+        throwError = true;
+      } else {
+        throw err;
+      }
+    }
+    assert(throwError);
+  });
+
+
+});

--- a/packages/sandbox-core/test/core/service/remoteDebugService.test.ts
+++ b/packages/sandbox-core/test/core/service/remoteDebugService.test.ts
@@ -15,24 +15,4 @@ describe('remoteDebugServiceTest', () => {
     assert(res.every((d) => d.debugPort && d.webSocketDebuggerUrl && d.token));
   });
 
-  it('getDebuggableHost without permission', async () => {
-    const remoteDebugService = await getInstance('remoteDebugService');
-    let throwError = false;
-    try {
-      await remoteDebugService.getDebuggableHost({
-        scope: 'test',
-        scopeName: 'noPermission',
-        uid: '1001',
-        ip: '127.0.0.1',
-      });
-    } catch (err) {
-      if (err.message.match(/no permission/)) {
-        throwError = true;
-      } else {
-        throw err;
-      }
-    }
-    assert(throwError);
-  });
-
 });


### PR DESCRIPTION
将权限判断从 service 中移到 controller 中，并加入对管理员角色的判断